### PR TITLE
[#85932896] some syntactic sugar and a nice bit of Rakefile work to add ...

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,15 @@
 begin
   require 'rspec/core/rake_task'
-
+  require 'cucumber/rake/task'
+  
+  Cucumber::Rake::Task.new(:features) do |t|
+    t.cucumber_opts = "features --format pretty"
+  end
+  
   RSpec::Core::RakeTask.new(:spec)
+  
+  task :default => [:spec,:features]
 
-  task :default => :spec
 rescue LoadError
   # no rspec available
 end

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,9 @@ begin
     t.cucumber_opts = "features --format pretty"
   end
   
-  RSpec::Core::RakeTask.new(:spec)
+  RSpec::Core::RakeTask.new(:spec) do |t|
+    t.rspec_opts = "--format documentation"
+  end
   
   task :default => [:spec,:features]
 

--- a/features/LogFileFinder.feature
+++ b/features/LogFileFinder.feature
@@ -5,3 +5,7 @@ Feature: Log File Finder
     Given I create a LogFileFinder pointed at the "TestLogs/VHLogs" folder
     When I ask for the main_output logs
     Then I should find 5 log files
+
+  Scenario: Log File Finder should throw an IOError when I try to create one with a bogus directory
+    When I create a LogFileFinder pointed at the "no-such-directory" folder
+    Then I should expect an IOError exception with message "The directory "no-such-directory" does not exist."

--- a/features/LogFileFinder.feature
+++ b/features/LogFileFinder.feature
@@ -1,6 +1,7 @@
 Feature: Log File Finder
-
-Scenario: Log File Finder should discover all the main output logs in the test folder
-  Given I create a LogFileFinder pointed at the "TestLogs/VHLogs" folder
-  When I ask for the main_output logs
-  Then I should find 19 log files
+  The LogFileFinder points to the top of a directory tree full of log files. It supports methods to return the list of relative paths of various types of log files located within the tree.
+  
+  Scenario: Log File Finder should discover all the main output logs in the test folder
+    Given I create a LogFileFinder pointed at the "TestLogs/VHLogs" folder
+    When I ask for the main_output logs
+    Then I should find 5 log files

--- a/features/step_defs/log_file_finder_steps.rb
+++ b/features/step_defs/log_file_finder_steps.rb
@@ -1,7 +1,11 @@
 require 'log_file_finder'
 
 Given(/^I create a LogFileFinder pointed at the "(.*?)" folder$/) do |dir_name|
-  @finder = LogFileFinder.new(dir_name)
+  begin
+    @finder = LogFileFinder.new(dir_name)
+  rescue Exception => exception
+    @exception = exception
+  end
 end
 
 When(/^I ask for the main_output logs$/) do
@@ -12,3 +16,16 @@ Then(/^I should find (\d+) log files$/) do |count_s|
   expect(@main_output_logs.length).to eq(count_s.to_i)
 end
 
+Then(/^I should expect an exception$/) do
+  expect(@exception).to_not be_nil
+end
+
+Then(/^I should expect an? (.*?) exception$/) do |exception_class|
+  step "I should expect an exception"
+  expect(@exception.class.name).to eq(exception_class)
+end
+
+Then(/^I should expect an? (.*?) exception with message "(.*?)"$/) do |exception_class,exception_message|
+  step "I should expect a #{exception_class} exception"
+  expect(@exception.to_s).to eq(exception_message)
+end

--- a/lib/log_file_finder.rb
+++ b/lib/log_file_finder.rb
@@ -1,14 +1,8 @@
-def all_main_output_logs(root_dir_name)
-  []
-end
-
 class LogFileFinder
 
   def initialize(root_log_dir)
     @root_log_dir = root_log_dir
-    if not Dir.exist?(root_log_dir)
-      raise IOError,"The directory \"#{root_log_dir}\" does not exist."
-    end
+    raise(IOError,"The directory \"#{root_log_dir}\" does not exist.") unless Dir.exist?(root_log_dir)
   end
 
   def main_output
@@ -19,4 +13,3 @@ class LogFileFinder
 
 
 end
-#Dir.glob("C:\Projects\Log-Viewer\TestLogs\VHLogs\**\MainOutputLog*.txt")


### PR DESCRIPTION
# Sugar Patch

*to be merged into [#85932896](https://www.pivotaltracker.com/story/show/85932896) as part of [Pull Request #3](https://github.com/Programming-Practice/Log-Viewer/pull/3)*

- Addresses this *suggestion* @jimcegelski mentioned regarding `raise(...) unless Dir.glob(log_file_root)`
- Adds `Cucumber::Rake::Task` to the `Rakefile`
- Adds `:features` task as a dependency of `:default`